### PR TITLE
Refactor transfer service with outbox pattern and value objects

### DIFF
--- a/CryptocurrencyExchange.Tests/Domain/TransferTests.cs
+++ b/CryptocurrencyExchange.Tests/Domain/TransferTests.cs
@@ -13,6 +13,13 @@ namespace CryptocurrencyExchange.Tests.Domain
         private const string Code = "123456";
 
         [Test]
+        public void Create_SenderEqualsReceiver_ShouldThrowSelfTransferException()
+        {
+            Assert.Throws<SelfTransferException>(() =>
+                Transfer.Create(SenderId, SenderId, CoinSymbol.Btc, 1m, Code));
+        }
+
+        [Test]
         public void Execute_CorrectCode_ShouldDeductSenderAndCreditReceiver()
         {
             var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 1m, Code);

--- a/CryptocurrencyExchange.Tests/Domain/TransferTests.cs
+++ b/CryptocurrencyExchange.Tests/Domain/TransferTests.cs
@@ -10,7 +10,7 @@ namespace CryptocurrencyExchange.Tests.Domain
     {
         private const int SenderId = 1;
         private const int ReceiverId = 2;
-        private const string Code = "123456";
+        private static readonly VerificationCode Code = new("123456");
 
         [Test]
         public void Create_SenderEqualsReceiver_ShouldThrowSelfTransferException()
@@ -26,7 +26,7 @@ namespace CryptocurrencyExchange.Tests.Domain
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 5m);
             var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
 
-            transfer.Execute(senderItem, receiverItem, new VerificationCode(Code));
+            transfer.Execute(senderItem, receiverItem, Code);
 
             Assert.That(senderItem.Amount.Value, Is.EqualTo(4m));
             Assert.That(receiverItem.Amount.Value, Is.EqualTo(1m));
@@ -51,10 +51,10 @@ namespace CryptocurrencyExchange.Tests.Domain
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 5m);
             var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
 
-            transfer.Execute(senderItem, receiverItem, new VerificationCode(Code));
+            transfer.Execute(senderItem, receiverItem, Code);
 
             Assert.Throws<InvalidOperationException>(() =>
-                transfer.Execute(senderItem, receiverItem, new VerificationCode(Code)));
+                transfer.Execute(senderItem, receiverItem, Code));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace CryptocurrencyExchange.Tests.Domain
             var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
 
             Assert.Throws<InsufficientFundsException>(() =>
-                transfer.Execute(senderItem, receiverItem, new VerificationCode(Code)));
+                transfer.Execute(senderItem, receiverItem, Code));
         }
     }
 }

--- a/CryptocurrencyExchange.Tests/Domain/VerificationCodeTests.cs
+++ b/CryptocurrencyExchange.Tests/Domain/VerificationCodeTests.cs
@@ -1,0 +1,26 @@
+using CryptocurrencyExchange.Core.ValueObject;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.Domain
+{
+    [TestFixture]
+    internal class VerificationCodeTests
+    {
+        [Test]
+        public void Generate_ProducesSixDigitCode()
+        {
+            var code = VerificationCode.Generate();
+
+            Assert.That(code.Value.Length, Is.EqualTo(6));
+            Assert.That(code.Value.All(char.IsDigit), Is.True);
+        }
+
+        [Test]
+        public void Generate_ProducesDifferentCodesAcrossCalls()
+        {
+            var codes = Enumerable.Range(0, 50).Select(_ => VerificationCode.Generate().Value).ToHashSet();
+
+            Assert.That(codes.Count, Is.GreaterThan(1));
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/Domain/WalletItemTests.cs
+++ b/CryptocurrencyExchange.Tests/Domain/WalletItemTests.cs
@@ -1,0 +1,33 @@
+using CryptocurrencyExchange.Core.Models;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.Domain
+{
+    [TestFixture]
+    internal class WalletItemTests
+    {
+        [Test]
+        public void HasSufficientBalance_WhenAmountEqualsBalance_ReturnsTrue()
+        {
+            var item = WalletItemMother.CreateUsdt(100m);
+
+            Assert.That(item.HasSufficientBalance(100m), Is.True);
+        }
+
+        [Test]
+        public void HasSufficientBalance_WhenAmountBelowBalance_ReturnsTrue()
+        {
+            var item = WalletItemMother.CreateUsdt(100m);
+
+            Assert.That(item.HasSufficientBalance(50m), Is.True);
+        }
+
+        [Test]
+        public void HasSufficientBalance_WhenAmountExceedsBalance_ReturnsFalse()
+        {
+            var item = WalletItemMother.CreateUsdt(50m);
+
+            Assert.That(item.HasSufficientBalance(100m), Is.False);
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/Infrastructure/TransferCompletedOutboxDispatcherTests.cs
+++ b/CryptocurrencyExchange.Tests/Infrastructure/TransferCompletedOutboxDispatcherTests.cs
@@ -1,0 +1,89 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Infrastructure.Outbox;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.Infrastructure
+{
+    [TestFixture]
+    public class TransferCompletedOutboxDispatcherTests
+    {
+        private Mock<ITransferCompletedOutboxRepository> _outboxRepo;
+        private Mock<IPublishEndpoint> _publishEndpoint;
+        private Mock<IUnitOfWork> _uow;
+        private TransferCompletedOutboxDispatcher _dispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _outboxRepo = new Mock<ITransferCompletedOutboxRepository>();
+            _publishEndpoint = new Mock<IPublishEndpoint>();
+            _uow = new Mock<IUnitOfWork>();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(_outboxRepo.Object);
+            services.AddSingleton(_publishEndpoint.Object);
+            services.AddSingleton(_uow.Object);
+
+            var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+            _dispatcher = new TransferCompletedOutboxDispatcher(scopeFactory, NullLogger<TransferCompletedOutboxDispatcher>.Instance);
+        }
+
+        [Test]
+        public async Task DispatchPendingAsync_WhenNoPendingEntries_DoesNotPublishOrCommit()
+        {
+            _outboxRepo.Setup(x => x.GetPendingAsync()).ReturnsAsync(new List<TransferCompletedOutbox>());
+
+            await _dispatcher.DispatchPendingAsync();
+
+            _publishEndpoint.Verify(
+                x => x.Publish(It.IsAny<TransferCompletedEvent>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            _uow.Verify(x => x.CommitAsync(), Times.Never);
+        }
+
+        [Test]
+        public async Task DispatchPendingAsync_WhenPendingEntriesExist_PublishesAndCommits()
+        {
+            var entry = new TransferCompletedOutbox(
+                transferId: 7, senderId: 1, senderEmail: "s@b.com",
+                receiverId: 2, receiverEmail: "r@b.com", amount: 5m, symbol: "btc");
+            _outboxRepo.Setup(x => x.GetPendingAsync()).ReturnsAsync(new List<TransferCompletedOutbox> { entry });
+
+            await _dispatcher.DispatchPendingAsync();
+
+            _publishEndpoint.Verify(
+                x => x.Publish(
+                    It.Is<TransferCompletedEvent>(e =>
+                        e.TransferId == 7 &&
+                        e.SenderId == 1 &&
+                        e.SenderEmail == "s@b.com" &&
+                        e.ReceiverId == 2 &&
+                        e.ReceiverEmail == "r@b.com" &&
+                        e.Amount == 5m &&
+                        e.Symbol == "btc"),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+            _uow.Verify(x => x.CommitAsync(), Times.Once);
+        }
+
+        [Test]
+        public async Task DispatchPendingAsync_WhenPendingEntriesExist_MarksEntriesAsProcessed()
+        {
+            var entry = new TransferCompletedOutbox(
+                transferId: 7, senderId: 1, senderEmail: "s@b.com",
+                receiverId: 2, receiverEmail: "r@b.com", amount: 5m, symbol: "btc");
+            _outboxRepo.Setup(x => x.GetPendingAsync()).ReturnsAsync(new List<TransferCompletedOutbox> { entry });
+
+            await _dispatcher.DispatchPendingAsync();
+
+            Assert.That(entry.ProcessedAt, Is.Not.Null);
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
@@ -151,23 +151,9 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         }
 
         [Test]
-        public void InitiateAsync_SenderHasNoWalletItem_ShouldThrowWalletItemNotFoundException()
-        {
-            var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
-            _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
-            _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
-            _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync((WalletItem)null);
-
-            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
-
-            Assert.ThrowsAsync<WalletItemNotFoundException>(async () =>
-                await _service.InitiateAsync(SenderId, dto, IdempotencyKey));
-        }
-
-        [Test]
         public async Task ConfirmAsync_ValidCode_ShouldCompleteTransfer()
         {
-            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, new VerificationCode("123456"));
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
             var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
 
@@ -186,7 +172,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         [Test]
         public async Task ConfirmAsync_AlreadyCompleted_ShouldReturnWithoutError()
         {
-            var completed = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var completed = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, new VerificationCode("123456"));
 
             _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(0, SenderId)).ReturnsAsync((Transfer)null);
             _transferRepo.Setup(x => x.GetCompletedByIdAndSenderAsync(0, SenderId)).ReturnsAsync(completed);
@@ -211,7 +197,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         [Test]
         public void ConfirmAsync_WrongCode_ShouldThrowInvalidVerificationCodeException()
         {
-            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, new VerificationCode("123456"));
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
             var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
 
@@ -228,7 +214,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         [Test]
         public async Task ConfirmAsync_ReceiverHasNoWalletItem_ShouldCreateAndTransfer()
         {
-            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, new VerificationCode("123456"));
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
 
             _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(0, SenderId)).ReturnsAsync(transfer);
@@ -245,7 +231,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         [Test]
         public async Task ConfirmAsync_ValidCode_ShouldPublishTransferCompletedEvent()
         {
-            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, new VerificationCode("123456"));
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
             var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
 

--- a/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
@@ -137,8 +137,12 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         public void InitiateAsync_SelfTransfer_ShouldThrowSelfTransferException()
         {
             var sender = new User(SenderEmail, new byte[] { 1 }, new byte[] { 2 });
+            var senderItem = new WalletItem(sender.Id, CoinSymbol.Btc);
+            senderItem.AddAmount(10m);
+
             _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
             _userRepo.Setup(x => x.GetByEmailAsync(SenderEmail)).ReturnsAsync(sender);
+            _walletRepo.Setup(x => x.GetWithUserAsync(sender.Id, It.IsAny<CoinSymbol>())).ReturnsAsync(senderItem);
 
             var dto = new InitiateTransferDto(SenderEmail, "btc", 5m);
 

--- a/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
@@ -151,24 +151,6 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         }
 
         [Test]
-        public void InitiateAsync_InsufficientFunds_ShouldThrowInsufficientFundsException()
-        {
-            var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
-            var senderItem = new WalletItem(SenderId, CoinSymbol.Btc);
-            senderItem.AddAmount(1m);
-            SetUserProperty(senderItem, new User(SenderEmail, new byte[] { 3 }, new byte[] { 4 }));
-
-            _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
-            _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
-            _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync(senderItem);
-
-            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 10m);
-
-            Assert.ThrowsAsync<InsufficientFundsException>(async () =>
-                await _service.InitiateAsync(SenderId, dto, IdempotencyKey));
-        }
-
-        [Test]
         public void InitiateAsync_SenderHasNoWalletItem_ShouldThrowWalletItemNotFoundException()
         {
             var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });

--- a/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
@@ -1,12 +1,10 @@
 using CryptocurrencyExchange.Application.Transfers;
-using CryptocurrencyExchange.Core.Events;
 using CryptocurrencyExchange.Core.Interfaces;
 using CryptocurrencyExchange.Core.Interfaces.Repositories;
 using CryptocurrencyExchange.Core.Models;
 using CryptocurrencyExchange.Core.ValueObject;
 using CryptocurrencyExchange.Core.ValueObject.User;
 using CryptocurrencyExchange.Exceptions;
-using MassTransit;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -23,8 +21,8 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         private Mock<IUserRepository> _userRepo;
         private Mock<IUnitOfWork> _uow;
         private Mock<ITransferVerificationOutboxRepository> _outboxRepo;
+        private Mock<ITransferCompletedOutboxRepository> _completedOutboxRepo;
         private Mock<ITransferIdempotentRequestRepository> _idempotentRepo;
-        private Mock<IPublishEndpoint> _publishEndpoint;
 
         private TransferService _service;
 
@@ -42,8 +40,8 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             _userRepo = new Mock<IUserRepository>();
             _uow = new Mock<IUnitOfWork>();
             _outboxRepo = new Mock<ITransferVerificationOutboxRepository>();
+            _completedOutboxRepo = new Mock<ITransferCompletedOutboxRepository>();
             _idempotentRepo = new Mock<ITransferIdempotentRequestRepository>();
-            _publishEndpoint = new Mock<IPublishEndpoint>();
 
             _uow.Setup(x => x.ExecuteInTransactionAsync(It.IsAny<Func<Task>>()))
                 .Returns<Func<Task>>(f => f());
@@ -54,8 +52,8 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
                 _userRepo.Object,
                 _uow.Object,
                 _outboxRepo.Object,
+                _completedOutboxRepo.Object,
                 _idempotentRepo.Object,
-                _publishEndpoint.Object,
                 NullLogger<TransferService>.Instance
             );
         }
@@ -229,7 +227,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         }
 
         [Test]
-        public async Task ConfirmAsync_ValidCode_ShouldPublishTransferCompletedEvent()
+        public async Task ConfirmAsync_ValidCode_ShouldWriteCompletionOutbox()
         {
             var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, new VerificationCode("123456"));
             var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
@@ -244,16 +242,14 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             var dto = new ConfirmTransferDto(0, "123456");
             await _service.ConfirmAsync(SenderId, dto);
 
-            _publishEndpoint.Verify(
-                x => x.Publish(
-                    It.Is<TransferCompletedEvent>(e =>
-                        e.SenderId == SenderId &&
-                        e.SenderEmail == SenderEmail.Value &&
-                        e.ReceiverId == ReceiverId &&
-                        e.ReceiverEmail == ReceiverEmail.Value &&
-                        e.Amount == 5m &&
-                        e.Symbol == "btc"),
-                    It.IsAny<CancellationToken>()),
+            _completedOutboxRepo.Verify(
+                x => x.AddAsync(It.Is<TransferCompletedOutbox>(e =>
+                    e.SenderId == SenderId &&
+                    e.SenderEmail == SenderEmail.Value &&
+                    e.ReceiverId == ReceiverId &&
+                    e.ReceiverEmail == ReceiverEmail.Value &&
+                    e.Amount == 5m &&
+                    e.Symbol == "btc")),
                 Times.Once);
         }
 

--- a/CryptocurrencyExchange/Application/Transfer/TransferService.cs
+++ b/CryptocurrencyExchange/Application/Transfer/TransferService.cs
@@ -53,10 +53,8 @@ namespace CryptocurrencyExchange.Application.Transfers
 
             var symbol = new CoinSymbol(dto.CoinSymbol);
 
-            var senderItem = await _walletItemRepository.GetWithUserAsync(senderId, symbol)
-                ?? throw new WalletItemNotFoundException();
-
-            if (senderItem.Amount.Value < dto.Amount)
+            var senderItem = await _walletItemRepository.GetWithUserAsync(senderId, symbol);
+            if (senderItem is null || !senderItem.HasSufficientBalance(dto.Amount))
                 throw new InsufficientFundsException();
 
             var code = GenerateCode();

--- a/CryptocurrencyExchange/Application/Transfer/TransferService.cs
+++ b/CryptocurrencyExchange/Application/Transfer/TransferService.cs
@@ -1,11 +1,9 @@
-using CryptocurrencyExchange.Core.Events;
 using CryptocurrencyExchange.Core.Interfaces;
 using CryptocurrencyExchange.Core.Interfaces.Repositories;
 using CryptocurrencyExchange.Core.Interfaces.Services;
 using CryptocurrencyExchange.Core.Models;
 using CryptocurrencyExchange.Core.ValueObject;
 using CryptocurrencyExchange.Exceptions;
-using MassTransit;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,8 +16,8 @@ namespace CryptocurrencyExchange.Application.Transfers
         private readonly IUserRepository _userRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ITransferVerificationOutboxRepository _outboxRepository;
+        private readonly ITransferCompletedOutboxRepository _completedOutboxRepository;
         private readonly ITransferIdempotentRequestRepository _idempotentRequestRepository;
-        private readonly IPublishEndpoint _publishEndpoint;
         private readonly ILogger<TransferService> _logger;
 
         public TransferService(
@@ -28,8 +26,8 @@ namespace CryptocurrencyExchange.Application.Transfers
             IUserRepository userRepository,
             IUnitOfWork unitOfWork,
             ITransferVerificationOutboxRepository outboxRepository,
+            ITransferCompletedOutboxRepository completedOutboxRepository,
             ITransferIdempotentRequestRepository idempotentRequestRepository,
-            IPublishEndpoint publishEndpoint,
             ILogger<TransferService> logger)
         {
             _transferRepository = transferRepository;
@@ -37,8 +35,8 @@ namespace CryptocurrencyExchange.Application.Transfers
             _userRepository = userRepository;
             _unitOfWork = unitOfWork;
             _outboxRepository = outboxRepository;
+            _completedOutboxRepository = completedOutboxRepository;
             _idempotentRequestRepository = idempotentRequestRepository;
-            _publishEndpoint = publishEndpoint;
             _logger = logger;
         }
 
@@ -116,12 +114,12 @@ namespace CryptocurrencyExchange.Application.Transfers
                 }
 
                 transfer.Execute(senderItem, receiverItem, codeVo);
-            });
 
-            var senderEmail = await _userRepository.GetEmailByIdAsync(senderId);
-            var receiverEmail = await _userRepository.GetEmailByIdAsync(transfer.ReceiverId);
-            await _publishEndpoint.Publish(new TransferCompletedEvent(
-                transfer.Id, senderId, senderEmail, transfer.ReceiverId, receiverEmail, transfer.Amount, transfer.Symbol.Value));
+                var senderEmail = await _userRepository.GetEmailByIdAsync(senderId);
+                var receiverEmail = await _userRepository.GetEmailByIdAsync(transfer.ReceiverId);
+                await _completedOutboxRepository.AddAsync(new TransferCompletedOutbox(
+                    transfer.Id, senderId, senderEmail, transfer.ReceiverId, receiverEmail, transfer.Amount, transfer.Symbol.Value));
+            });
 
             _logger.LogInformation("Transfer {TransferId} completed by user {SenderId}", dto.TransferId, senderId);
         }

--- a/CryptocurrencyExchange/Application/Transfer/TransferService.cs
+++ b/CryptocurrencyExchange/Application/Transfer/TransferService.cs
@@ -51,9 +51,6 @@ namespace CryptocurrencyExchange.Application.Transfers
             var receiver = await _userRepository.GetByEmailAsync(dto.ReceiverEmail)
                 ?? throw new UserNotFoundException();
 
-            if (receiver.Id == senderId)
-                throw new SelfTransferException();
-
             var symbol = new CoinSymbol(dto.CoinSymbol);
 
             var senderItem = await _walletItemRepository.GetWithUserAsync(senderId, symbol)

--- a/CryptocurrencyExchange/Application/Transfer/TransferService.cs
+++ b/CryptocurrencyExchange/Application/Transfer/TransferService.cs
@@ -57,7 +57,7 @@ namespace CryptocurrencyExchange.Application.Transfers
             if (senderItem is null || !senderItem.HasSufficientBalance(dto.Amount))
                 throw new InsufficientFundsException();
 
-            var code = GenerateCode();
+            var code = VerificationCode.Generate();
             var idempotentRequest = new TransferIdempotentRequest(idempotencyKey, senderId);
             Transfer transfer = null;
 
@@ -68,7 +68,7 @@ namespace CryptocurrencyExchange.Application.Transfers
                     await _idempotentRequestRepository.AddAsync(idempotentRequest);
                     transfer = Transfer.Create(senderId, receiver.Id, symbol, dto.Amount, code);
                     await _transferRepository.AddAsync(transfer);
-                    await _outboxRepository.AddAsync(new TransferVerificationOutbox(senderItem.User.Email, code));
+                    await _outboxRepository.AddAsync(new TransferVerificationOutbox(senderItem.User.Email, code.Value));
                     await _unitOfWork.CommitAsync();
                     idempotentRequest.SetTransferId(transfer.Id);
                 });
@@ -125,8 +125,6 @@ namespace CryptocurrencyExchange.Application.Transfers
 
             _logger.LogInformation("Transfer {TransferId} completed by user {SenderId}", dto.TransferId, senderId);
         }
-
-        private static string GenerateCode() => Random.Shared.Next(100_000, 1_000_000).ToString();
 
         private static bool IsDuplicateKeyException(DbUpdateException ex) =>
             ex.InnerException is SqlException sqlEx &&

--- a/CryptocurrencyExchange/Core/Entities/Transfer.cs
+++ b/CryptocurrencyExchange/Core/Entities/Transfer.cs
@@ -20,6 +20,9 @@ namespace CryptocurrencyExchange.Core.Models
 
         public static Transfer Create(int senderId, int receiverId, CoinSymbol symbol, decimal amount, string verificationCode)
         {
+            if (senderId == receiverId)
+                throw new SelfTransferException();
+
             return new Transfer
             {
                 SenderId = senderId,

--- a/CryptocurrencyExchange/Core/Entities/Transfer.cs
+++ b/CryptocurrencyExchange/Core/Entities/Transfer.cs
@@ -18,7 +18,7 @@ namespace CryptocurrencyExchange.Core.Models
 
         private Transfer() { }
 
-        public static Transfer Create(int senderId, int receiverId, CoinSymbol symbol, decimal amount, string verificationCode)
+        public static Transfer Create(int senderId, int receiverId, CoinSymbol symbol, decimal amount, VerificationCode code)
         {
             if (senderId == receiverId)
                 throw new SelfTransferException();
@@ -29,7 +29,7 @@ namespace CryptocurrencyExchange.Core.Models
                 ReceiverId = receiverId,
                 Symbol = symbol,
                 Amount = amount,
-                Code = new VerificationCode(verificationCode),
+                Code = code,
                 Status = TransferStatus.Pending,
                 CreatedAt = DateTime.UtcNow
             };

--- a/CryptocurrencyExchange/Core/Entities/TransferCompletedOutbox.cs
+++ b/CryptocurrencyExchange/Core/Entities/TransferCompletedOutbox.cs
@@ -1,0 +1,39 @@
+namespace CryptocurrencyExchange.Core.Models
+{
+    public class TransferCompletedOutbox
+    {
+        public int Id { get; private set; }
+        public int TransferId { get; private set; }
+        public int SenderId { get; private set; }
+        public string SenderEmail { get; private set; }
+        public int ReceiverId { get; private set; }
+        public string ReceiverEmail { get; private set; }
+        public decimal Amount { get; private set; }
+        public string Symbol { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime? ProcessedAt { get; private set; }
+
+        private TransferCompletedOutbox() { }
+
+        public TransferCompletedOutbox(
+            int transferId,
+            int senderId,
+            string senderEmail,
+            int receiverId,
+            string receiverEmail,
+            decimal amount,
+            string symbol)
+        {
+            TransferId = transferId;
+            SenderId = senderId;
+            SenderEmail = senderEmail;
+            ReceiverId = receiverId;
+            ReceiverEmail = receiverEmail;
+            Amount = amount;
+            Symbol = symbol;
+            CreatedAt = DateTime.UtcNow;
+        }
+
+        public void MarkProcessed() => ProcessedAt = DateTime.UtcNow;
+    }
+}

--- a/CryptocurrencyExchange/Core/Entities/WalletItem.cs
+++ b/CryptocurrencyExchange/Core/Entities/WalletItem.cs
@@ -26,6 +26,8 @@ namespace CryptocurrencyExchange.Core.Models
             Amount = Balance.Zero;
         }
 
+        public bool HasSufficientBalance(decimal amount) => Amount.Value >= amount;
+
         public void AddAmount(decimal amount)
         {
             Amount += amount;

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferCompletedOutboxRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferCompletedOutboxRepository.cs
@@ -1,0 +1,10 @@
+using CryptocurrencyExchange.Core.Models;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Repositories
+{
+    public interface ITransferCompletedOutboxRepository
+    {
+        Task AddAsync(TransferCompletedOutbox entry);
+        Task<List<TransferCompletedOutbox>> GetPendingAsync();
+    }
+}

--- a/CryptocurrencyExchange/Core/ValueObject/VerificationCode.cs
+++ b/CryptocurrencyExchange/Core/ValueObject/VerificationCode.cs
@@ -13,5 +13,8 @@ namespace CryptocurrencyExchange.Core.ValueObject
         }
 
         public override string ToString() => Value;
+
+        public static VerificationCode Generate() =>
+            new(Random.Shared.Next(100_000, 1_000_000).ToString());
     }
 }

--- a/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
+++ b/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
@@ -41,6 +41,7 @@ namespace CryptocurrencyExchange.Extensions
             services.AddScoped<ITransferRepository, EfTransferRepository>();
             services.AddScoped<IUserRegistrationOutboxRepository, EfUserRegistrationOutboxRepository>();
             services.AddScoped<ITransferVerificationOutboxRepository, EfTransferVerificationOutboxRepository>();
+            services.AddScoped<ITransferCompletedOutboxRepository, EfTransferCompletedOutboxRepository>();
             services.AddScoped<ITransferIdempotentRequestRepository, EfTransferIdempotentRequestRepository>();
             services.AddScoped<IDatabaseHealthChecker, EfDatabaseHealthChecker>();
 
@@ -138,6 +139,7 @@ namespace CryptocurrencyExchange.Extensions
             services.AddHostedService<StakingScheduler>();
             services.AddHostedService<OutboxDispatcher>();
             services.AddHostedService<TransferOutboxDispatcher>();
+            services.AddHostedService<TransferCompletedOutboxDispatcher>();
             return services;
         }
 

--- a/CryptocurrencyExchange/Infrastructure/Outbox/TransferCompletedOutboxDispatcher.cs
+++ b/CryptocurrencyExchange/Infrastructure/Outbox/TransferCompletedOutboxDispatcher.cs
@@ -1,0 +1,55 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using MassTransit;
+
+namespace CryptocurrencyExchange.Infrastructure.Outbox
+{
+    public class TransferCompletedOutboxDispatcher : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<TransferCompletedOutboxDispatcher> _logger;
+
+        public TransferCompletedOutboxDispatcher(IServiceScopeFactory scopeFactory, ILogger<TransferCompletedOutboxDispatcher> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await DispatchPendingAsync();
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+        }
+
+        internal async Task DispatchPendingAsync()
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var outboxRepository = scope.ServiceProvider.GetRequiredService<ITransferCompletedOutboxRepository>();
+            var publishEndpoint = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var pending = await outboxRepository.GetPendingAsync();
+            if (pending.Count == 0) return;
+
+            foreach (var entry in pending)
+            {
+                await publishEndpoint.Publish(new TransferCompletedEvent(
+                    entry.TransferId,
+                    entry.SenderId,
+                    entry.SenderEmail,
+                    entry.ReceiverId,
+                    entry.ReceiverEmail,
+                    entry.Amount,
+                    entry.Symbol));
+                entry.MarkProcessed();
+            }
+
+            await unitOfWork.CommitAsync();
+            _logger.LogInformation("Dispatched {Count} transfer completed outbox entries", pending.Count);
+        }
+    }
+}

--- a/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
@@ -20,6 +20,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
         public DbSet<Transfer> Transfers { get; set; }
         public DbSet<UserRegistrationOutbox> UserRegistrationOutbox { get; set; }
         public DbSet<TransferVerificationOutbox> TransferVerificationOutbox { get; set; }
+        public DbSet<TransferCompletedOutbox> TransferCompletedOutbox { get; set; }
         public DbSet<TransferIdempotentRequest> TransferIdempotentRequests { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -31,6 +32,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
             ConfigureLogEntry(modelBuilder);
             ConfigureUserRegistrationOutbox(modelBuilder);
             ConfigureTransferVerificationOutbox(modelBuilder);
+            ConfigureTransferCompletedOutbox(modelBuilder);
             ConfigureTransferIdempotentRequest(modelBuilder);
         }
 
@@ -116,6 +118,18 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
                 b.HasKey(e => e.Id);
                 b.Property(e => e.Email).IsRequired().HasMaxLength(256);
                 b.Property(e => e.VerificationCode).IsRequired().HasMaxLength(6);
+                b.HasIndex(e => e.ProcessedAt);
+            });
+        }
+
+        private static void ConfigureTransferCompletedOutbox(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TransferCompletedOutbox>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.SenderEmail).IsRequired().HasMaxLength(256);
+                b.Property(e => e.ReceiverEmail).IsRequired().HasMaxLength(256);
+                b.Property(e => e.Symbol).IsRequired().HasMaxLength(16);
                 b.HasIndex(e => e.ProcessedAt);
             });
         }

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferCompletedOutboxRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferCompletedOutboxRepository.cs
@@ -1,0 +1,22 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
+{
+    public class EfTransferCompletedOutboxRepository : ITransferCompletedOutboxRepository
+    {
+        private readonly DataContext _context;
+
+        public EfTransferCompletedOutboxRepository(DataContext context)
+            => _context = context;
+
+        public async Task AddAsync(TransferCompletedOutbox entry)
+            => await _context.TransferCompletedOutbox.AddAsync(entry);
+
+        public async Task<List<TransferCompletedOutbox>> GetPendingAsync()
+            => await _context.TransferCompletedOutbox
+                .Where(e => e.ProcessedAt == null)
+                .ToListAsync();
+    }
+}

--- a/CryptocurrencyExchange/Migrations/20260509103059_AddTransferCompletedOutbox.Designer.cs
+++ b/CryptocurrencyExchange/Migrations/20260509103059_AddTransferCompletedOutbox.Designer.cs
@@ -4,6 +4,7 @@ using CryptocurrencyExchange.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CryptocurrencyExchange.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260509103059_AddTransferCompletedOutbox")]
+    partial class AddTransferCompletedOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CryptocurrencyExchange/Migrations/20260509103059_AddTransferCompletedOutbox.cs
+++ b/CryptocurrencyExchange/Migrations/20260509103059_AddTransferCompletedOutbox.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CryptocurrencyExchange.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransferCompletedOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TransferCompletedOutbox",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TransferId = table.Column<int>(type: "int", nullable: false),
+                    SenderId = table.Column<int>(type: "int", nullable: false),
+                    SenderEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    ReceiverId = table.Column<int>(type: "int", nullable: false),
+                    ReceiverEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Symbol = table.Column<string>(type: "nvarchar(16)", maxLength: 16, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ProcessedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TransferCompletedOutbox", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TransferCompletedOutbox_ProcessedAt",
+                table: "TransferCompletedOutbox",
+                column: "ProcessedAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TransferCompletedOutbox");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Moved transfer completion event publishing to a transactional outbox (`TransferCompletedOutbox` entity + repository + dispatcher)
- Extracted `VerificationCode` as a value object; moved self-transfer and balance-check logic into domain entities
- Treat missing wallet as insufficient funds instead of a distinct error path